### PR TITLE
Hotfix/ch5 add docker run platform

### DIFF
--- a/ch5/Makefile
+++ b/ch5/Makefile
@@ -16,7 +16,7 @@ crud-pydantic:
 
 server:
 	docker build -f Dockerfile -t ch5-api-server .
-	docker run --name api-server -p 8000:8000 -d ch5-api-server
+	docker run --name api-server --platform linux/amd64 -p 8000:8000 -d ch5-api-server
 
 server-clean:
 	docker rm -f api-server


### PR DESCRIPTION
Signed-off-by: datawhales <datawhales@gmail.com>

## Changes?
Docker compose 에서 platform 을 모두 명시함에 따라 ch5 에서 container 를 띄울 때에도 platform 을 명시하였습니다. 
참고로 ch5 는 다른 챕터와 독립적인 챕터이기 때문에 docker compose 를 사용하지 않습니다.
