### PR TITLE
fix: postgresql DB name

### DIFF
--- a/part3/docker-compose.yaml
+++ b/part3/docker-compose.yaml
@@ -7,9 +7,9 @@ services:
     environment:
       POSTGRES_USER: mlflowuser
       POSTGRES_PASSWORD: mlflowpassword
-      POSTGRES_DB: mlflow
+      POSTGRES_DB: mlflowdatabase
     healthcheck:
-      test: ["CMD", "pg_isready", "-q", "-U", "mlflowuser", "-d", "mlflow"]
+      test: ["CMD", "pg_isready", "-q", "-U", "mlflowuser", "-d", "mlflowdatabase"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -53,6 +53,6 @@ services:
         mc config host add mlflowminio http://mlflow-artifact-store:9000 minio miniostorage &&
         mc mb --ignore-existing mlflowminio/mlflow
         mlflow server \
-        --backend-store-uri postgresql://mlflowuser:mlflowpassword@mlflow-backend-store/mlflow \
+        --backend-store-uri postgresql://mlflowuser:mlflowpassword@mlflow-backend-store/mlflowdatabase \
         --default-artifact-root s3://mlflow/ \
         --host 0.0.0.0


### PR DESCRIPTION
Signed-off-by: DaeungKim <daeung.kim@makinarocks.ai>

## Changes?
<!-- 이 PR 로 인해서 무엇이 변경되었는지 작성해주세요 -->
Chapter 03. Model Registry의 `docker-compose.yaml`의 `POSTGRES_DB` 이름을 수정. (`mlflow` -> `mlflowdatabase`)

<img width="686" alt="image" src="https://user-images.githubusercontent.com/41335296/210167714-2c492b9a-ff90-4f7e-a722-1eb493318abf.png">


## Why we need?
<!-- 이 PR 이 왜 필요한지 작성해주세요 -->
- 스펙 명세서에서 지정한 DB 이름과 다르므로 수정 필요
<img width="544" alt="image" src="https://user-images.githubusercontent.com/41335296/210168020-72187b1c-a80e-4659-912c-684c48c80d11.png">
